### PR TITLE
Add support for methods in routing

### DIFF
--- a/App/Controllers/Home.php
+++ b/App/Controllers/Home.php
@@ -11,4 +11,9 @@ class Home extends \Core\Controller
     {
         View::renderTemplate('Home/index.html.twig');
     }
+
+    public function indexPostAction()
+    {
+        View::renderTemplate('Home/post.html.twig');
+    }
 }

--- a/App/Views/Home/index.html.twig
+++ b/App/Views/Home/index.html.twig
@@ -7,6 +7,9 @@
     <div class="banner__text">
       Traveling has never been <span style="font-style: italic;">this</span> easy.
     </div>
+    <form method="post" action="/">
+      <input type="submit" text="test" />
+    </form>
   </div>
   <h2 class="content-header">Promotions</h2>
   <div class="content">

--- a/App/Views/Home/post.html.twig
+++ b/App/Views/Home/post.html.twig
@@ -1,0 +1,8 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Home{% endblock %}
+
+{% block body %}
+
+  <h1>Hello from post!</h1>
+{% endblock %}

--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -23,13 +23,15 @@ abstract class Controller
     {
         $method = $name . 'Action';
 
-        if (method_exists($this, $method)) {
-            if ($this->before() !== false) {
-                call_user_func_array([$this, $method], $args);
-                $this->after();
-            }
-        } else {
-            throw new \Exception("Method $method not found in controller " . get_class($this));
+        if (!method_exists($this, $method)) {
+            throw new \Exception(
+                "Method $method not found in controller " . get_class($this)
+            );
+        }
+
+        if ($this->before() !== false) {
+            call_user_func_array([$this, $method], $args);
+            $this->after();
         }
     }
 

--- a/Core/Route.php
+++ b/Core/Route.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Core;
+
+class Route
+{
+    protected $params = [];
+    protected $pattern = '';
+    protected $method = '';
+
+    public function __construct($pattern, $params, $method)
+    {
+        $this->pattern = $pattern;
+        $this->params = $params;
+        $this->method = $method;
+    }
+
+    public function getParams()
+    {
+        return $this->params;
+    }
+
+    public function getPattern()
+    {
+        return $this->pattern;
+    }
+
+    public function getMethod()
+    {
+        return $this->method;
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -17,8 +17,24 @@ set_exception_handler('Core\Error::exceptionHandler');
 $router = new Core\Router();
 
 // Add the routes
-$router->add('', ['controller' => 'Home', 'action' => 'index']);
-$router->add('circuits/', ['controller' => 'Circuits', 'action' => 'show']);
+$router->add(
+    '',
+    ['controller' => 'Home', 'action' => 'index'],
+    'GET'
+);
+
+$router->add(
+    '',
+    ['controller' => 'Home', 'action' => 'indexPost'],
+    'POST'
+);
+
+
+$router->add(
+    'circuits/',
+    ['controller' => 'Circuits', 'action' => 'show'],
+    'GET'
+);
 
 /**
  * Convert URI to QueryString
@@ -36,4 +52,4 @@ if ($matches[0][2] != '') {
     $QueryString .= "&" . $matches[0][2]; // Group 2: params
 }
 
-$router->dispatch($QueryString); // Send the query string to the router
+$router->dispatch($QueryString, $_SERVER['REQUEST_METHOD']); // Send the query string to the router


### PR DESCRIPTION
This PR adds the ability for the router to match request methods (e.g. GET, POST or DELETE) in routes.

This comes with an already implemented example, when you press the "submit" button on the main page, it sends a POST request to the server which then uses a different action to render the same path.