### PR TITLE
Add new editorconfig rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,8 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true
+max_line_length = 80
 
 [*.php]
 indent_size = 4


### PR DESCRIPTION
This PR adds the following rules to the .editorconfig file: 
```
trim_trailing_whitespace = true
max_line_length = 80
```
