### PR TITLE
Fix admins being able to send messages in rooms they're not in

### DIFF
--- a/App/Controllers/SupportChatAdmin.php
+++ b/App/Controllers/SupportChatAdmin.php
@@ -21,12 +21,17 @@ class SupportChatAdmin extends Controller
     public function sendMessage()
     {
         $errors = [];
+        // TODO: i18n
         if (empty($_POST['content'])) {
             $errors[] = 'Votre message ne peu être vide';
         }
 
         if (empty($_POST['room_id'])) {
             $errors[] = 'Vous devez fournir une pièce';
+        }
+
+        if (!SupportChat::employeeCanSendIn($_SESSION['employee']['id'], $_POST['room_id'])) {
+            $errors[] = 'Vous ne pouvez envoyer de message dans cette session';
         }
 
         if (!empty($errors)) {

--- a/App/Models/SupportChat.php
+++ b/App/Models/SupportChat.php
@@ -44,6 +44,27 @@ class SupportChat extends Model
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    public static function employeeCanSendIn($employee_id, $room_id)
+    {
+        $db = static::getDB();
+        $stmt = $db->prepare(
+            'SELECT id
+             FROM chat_rooms
+             WHERE
+               id = :room_id AND
+               employee_id = :employee_id AND
+               is_active = 1
+             LIMIT 1;'
+        );
+
+        $stmt->bindValue(':room_id', $room_id, PDO::PARAM_INT);
+        $stmt->bindValue(':employee_id', $employee_id, PDO::PARAM_INT);
+
+        $stmt->execute();
+        return $stmt->fetch() != false;
+
+    }
+
     public static function memberCanSendIn($member_id, $room_id)
     {
         $db = static::getDB();

--- a/public/js/support_chat.js
+++ b/public/js/support_chat.js
@@ -139,10 +139,18 @@
   }
 
   $('#support-chat__form').ajaxForm({
-    success: () => {
+    beforeSend: () => {
       form.reset()
     }
   }) // Make the form use Ajax
+
+  $('#support-chat__textarea').keypress((e) => {
+    if (e.which == 13) { // Enter key
+      $('#support-chat__form').submit()
+      $(this).val("")
+      e.preventDefault()
+    }
+  })
 
   button.onclick = () => {
     button.classList.add('hidden')

--- a/public/js/support_chat_admin.js
+++ b/public/js/support_chat_admin.js
@@ -28,13 +28,9 @@
     room_id_input.setAttribute('value', id)
 
     if (active) {
-      text_area.removeAttribute('disabled')
-      send_btn.removeAttribute('disabled')
       actions_bar.classList.remove('hidden')
     }
     else {
-      text_area.setAttribute('disabled', '')
-      send_btn.setAttribute('disabled', '')
       actions_bar.classList.add('hidden')
     }
 
@@ -42,9 +38,13 @@
     join_action.classList.add('hidden')
 
     if (employee_id == "") {
+      text_area.setAttribute('disabled', '')
+      send_btn.setAttribute('disabled', '')
       join_action.classList.remove('hidden')
     }
     else if (can_leave) {
+      text_area.removeAttribute('disabled')
+      send_btn.removeAttribute('disabled')
       leave_action.classList.remove('hidden')
     }
 
@@ -143,10 +143,18 @@
   }
 
   $('#support-chat__form').ajaxForm({
-    success: () => {
+    beforeSend: () => {
       form.reset()
     }
   }) // Make the form use Ajax
+
+  $('#support-chat__textarea').keypress((e) => {
+    if (e.which == 13) { // Enter key
+      $('#support-chat__form').submit()
+      $(this).val("")
+      e.preventDefault()
+    }
+  })
 
   button.onclick = () => {
     button.classList.add('hidden')


### PR DESCRIPTION
This PR fixes a minor bug in the admin chat interface by adding server side and client side validations so that admins can't send messages in rooms they didn't join.

Also, pressing enter while the cursor is in the textarea now sends the message.