### PR TITLE
Add functional password reset

### DIFF
--- a/App/Controllers/ForgotPassword.php
+++ b/App/Controllers/ForgotPassword.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Controllers;
+
+use \App\Helpers\EmailHelpers;
+use \App\Helpers\LoginHelpers;
+use \App\Models\Member;
+use \App\Models\PasswordReset;
+use \Core\Controller;
+use \Core\View;
+
+class ForgotPassword extends Controller
+{
+
+    public function confirmResetAction()
+    {
+        $errors = [];
+        if (empty($_POST['password'])) {
+            $errors['password'][] = 'Veuillez fournir un mot de passe';
+        }
+
+        if (empty($_POST['token'])) {
+            $errors['token'][] = 'Erreur, veuillez essayer de nouveau';
+        }
+
+        if (!empty($errors)) {
+            http_response_code(400);
+            View::renderJSON(['errors' => $errors]);
+            return;
+        }
+
+        $token = $_POST['token'];
+
+        if (!PasswordReset::verifyToken($token)) {
+            View::renderTemplate('500.html.twig');
+            return;
+        }
+
+        $member_id = PasswordReset::getMemberFromToken($token);
+
+        $errors = LoginHelpers::validatePassword($_POST['password']);
+
+        if (!empty($errors)) {
+            View::renderTemplate('500.html.twig');
+            return;
+        }
+
+        Member::updateMemberPassword($_POST['password'], $member_id);
+        PasswordReset::deleteTokens($member_id);
+
+        header('Location: /');
+    }
+
+    public function showResetPageAction()
+    {
+        if (empty($this->route_params['variables']['token'])) {
+            View::renderTemplate("404.html.twig");
+            return;
+        }
+
+
+        $token = $this->route_params['variables']['token'];
+
+        if (!PasswordReset::verifyToken($token)) {
+            View::renderTemplate("404.html.twig");
+            return;
+        }
+
+        View::renderTemplate('Members/password_reset.html.twig', ['token' => $token]);
+    }
+
+    public function sendEmailAction()
+    {
+        $errors = [];
+        if (empty($_POST['email'])) {
+            $errors['email'][] = 'Veuillez fournir un email';
+        }
+
+        if (!empty($errors)) {
+            http_response_code(400);
+            View::renderJSON(['errors' => $errors]);
+            return;
+        }
+
+        $email = $_POST['email'];
+        $member = Member::getByEmail($email);
+
+        if ($member == false) {
+            return;
+        }
+
+        $token = PasswordReset::generateToken($email);
+
+        if ($token == false) {
+            return;
+        }
+
+        $email_content = View::outputTemplate(
+            'Members/password_reset_email.html.twig',
+            ['token' => $token]
+        );
+
+        $member_full_name = $member['first_name'] . ' ' . $member['last_name'];
+
+        EmailHelpers::sendEmail(
+            $email,
+            $member_full_name,
+            'Réinitialisation de mot de passe',
+            $email_content
+        );
+    }
+}

--- a/App/Controllers/Newsletters.php
+++ b/App/Controllers/Newsletters.php
@@ -96,6 +96,3 @@ class Newsletters extends \Core\Controller
         EmailHelpers::sendEmailBBC($bcc,$_POST['inputSubject'],$_POST['inputContent']);
     }
 }
-
-
-

--- a/App/Db/CreateDB.sql
+++ b/App/Db/CreateDB.sql
@@ -854,6 +854,13 @@ CREATE TABLE `waiting_lists` (
                                  `member_id` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
+CREATE TABLE `password_reset` (
+  `id` int(11) NOT NULL,
+  `token` varchar(64) CHARACTER SET utf8 NOT NULL,
+  `member_id` int(11) NOT NULL,
+  `creation_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 --
 -- Index pour les tables déchargées
 --
@@ -1314,6 +1321,9 @@ ALTER TABLE `members_chat_lines`
   ADD KEY `member_id` (`member_id`),
   ADD KEY `chat_line_id` (`chat_line_id`);
 
+ALTER TABLE `password_reset`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `member_id` (`member_id`);
 
 --
 -- AUTO_INCREMENT pour la table `accommodations`
@@ -1622,6 +1632,9 @@ ALTER TABLE `employees_chat_lines`
 
 ALTER TABLE `members_chat_lines`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+ALTER TABLE `password_reset`
+  MODIFY `id` INT(11) NOT NULL AUTO_INCREMENT;
 
 
 --
@@ -1954,6 +1967,9 @@ ALTER TABLE `employees_chat_lines`
 ALTER TABLE `members_chat_lines`
 ADD CONSTRAINT `members_chat_lines_ibfk_1` FOREIGN KEY (`member_id`) REFERENCES `members` (`id`),
 ADD CONSTRAINT `members_chat_lines_ibfk_2` FOREIGN KEY (`chat_line_id`) REFERENCES `chat_lines` (`id`);
+
+ALTER TABLE `password_reset`
+ADD CONSTRAINT `password_reset_ibfk_1` FOREIGN KEY (`member_id`) REFERENCES `members` (`id`);
 
 COMMIT;
 

--- a/App/Helpers/EmailHelpers.php
+++ b/App/Helpers/EmailHelpers.php
@@ -16,6 +16,7 @@ class EmailHelpers
         $errors = [];
         $mail = new PHPMailer();
         $mail->IsSMTP();
+        $mail->CharSet = 'UTF-8';
         $mail->Mailer = "smtp";
         $mail->SMTPDebug = 1;
         $mail->SMTPAuth = TRUE;

--- a/App/Models/Newsletter.php
+++ b/App/Models/Newsletter.php
@@ -20,7 +20,7 @@ class Newsletter extends \Core\Model
                   ORDER BY id DESC
             ) r
             ON t.id = r.newsletter_id
-            GROUP by t.id
+            GROUP by t.id, t.name, r.newsletter_message_date, r.subject
             ');
         $stmt->execute();
         return $stmt->fetchAll();

--- a/App/Models/PasswordReset.php
+++ b/App/Models/PasswordReset.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use \App\Helpers\LoginHelpers;
+use \Core\Model;
+use PDO;
+
+class PasswordReset extends Model
+{
+    public static function generateToken($email)
+    {
+        $db = static::getDB();
+
+        $stmt = $db->prepare(
+            'SELECT id FROM members WHERE email = :email'
+        );
+
+        $stmt->bindValue(':email', $email, PDO::PARAM_STR);
+        $stmt->execute();
+        $fetched_data = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($fetched_data == false) {
+            return false;
+        }
+
+        $db->beginTransaction();
+
+        $member_id = $fetched_data['id'];
+        $token = LoginHelpers::generateRandomSalt();
+
+        $stmt = $db->prepare(
+            'INSERT INTO password_reset (member_id, token)
+             VALUES (:member_id, :token)'
+        );
+
+        $stmt->bindValue(':token', $token, PDO::PARAM_STR);
+        $stmt->bindValue(':member_id', $member_id, PDO::PARAM_STR);
+        $stmt->execute();
+
+        $db->commit();
+        return $token;
+    }
+
+    public static function verifyToken($token)
+    {
+        $db = static::getDB();
+        $stmt = $db->prepare('SELECT id FROM password_reset WHERE token = :token');
+        $stmt->bindValue(':token', $token, PDO::PARAM_STR);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC) != false;
+    }
+
+    public static function deleteTokens($member_id)
+    {
+        $db = static::getDB();
+        $stmt = $db->prepare('DELETE FROM password_reset WHERE member_id = :member_id');
+        $stmt->bindValue(':member_id', $member_id, PDO::PARAM_INT);
+        $stmt->execute();
+    }
+
+    public static function getMemberFromToken($token)
+    {
+        $db = static::getDB();
+        $stmt = $db->prepare(
+            'SELECT member_id FROM password_reset
+             WHERE token = :token'
+        );
+
+        $stmt->bindValue(':token', $token, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->fetch(PDO::FETCH_ASSOC)['member_id'];
+    }
+}

--- a/App/Views/Members/password_reset.html.twig
+++ b/App/Views/Members/password_reset.html.twig
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="shortcut icon" type="image/png" href="/images/labernois_logo.png"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Dancing+Script|Fugaz+One|Permanent+Marker&display=swap">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/custom_bootstrap.css"/>
+    <link rel="stylesheet" href="/css/main.css"/>
+    <link rel="stylesheet" href="/css/nav.css"/>
+    <link rel="stylesheet" href="/css/footer.css"/>
+    <link rel="stylesheet" href="/css/password_reset.css"/>
+    <title>Réinitialisation du mot de passe | Le Labernois</title>
+  </head>
+
+  <body>
+    <header>
+      <a href="#" class="logo">
+        <img alt="logo_with_text" src="/images/labernois_logo_text.png"/>
+      </a>
+    </header>
+    <main>
+      <div class="password-reset-container">
+        <h1>Réinitialisation du mot de passe</h1>
+        <form id="reset_form" method="post" action="password_reset">
+          <input id="reset_form_token" name="token" type="hidden" value="{{ token|e("html_attr") }}"/>
+          <label for="reset_form_password">Nouveau mot de passe</label>
+          <input id="reset_form_password" name="password" type="password" />
+          <label for="reset_form_password_confirmation">Confirmation du nouveau mot de passe</label>
+          <input id="reset_form_password_confirmation" name="password_confirmation" type="password" />
+          <input id="reset_form_submit" class="btn btn-primary" type="submit" value="Réinitialiser le mot de passe" />
+        </form>
+      </div>
+    </main>
+    <footer id="footer">
+      <div class="footer__left">
+        <img alt="logo" src="/images/labernois_logo.png"/>
+      </div>
+      <div class="footer__middle">
+        <div class="footer__links">
+          <a href="" class="link-colors">Contact Us</a>
+          <a href="" class="link-colors">Newsletter</a>
+          <a href="/admin" class="link-colors">Administration</a>
+        </div>
+        <p class="footer-copyright">
+          Copyright © 2019 MBGLA LABERNOIS, Inc. All rights reserved.</p>
+      </div>
+      <div class="footer__right"></div>
+    </footer>
+  </body>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+  <script src="/js/password_reset.js"></script>
+</html>

--- a/App/Views/Members/password_reset_email.html.twig
+++ b/App/Views/Members/password_reset_email.html.twig
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="fr" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <p>
+      Cliquez <a href="http://localhost/password_reset?token={{ token }}">ici</a>
+      pour Réinitialiser votre mot de passe.
+    </p>
+    <p>
+      Vous avez reçu ce email car vous avez fait une demande de réinitialisation
+      de mot de passe. Si vous n'avez pas fait cette demande, vous pouvez ignorer
+      ce email.
+    </p>
+  </body>
+</html>

--- a/App/Views/Members/reset.html.twig
+++ b/App/Views/Members/reset.html.twig
@@ -7,9 +7,9 @@
             <i class="fa fa-lock fa-4x"></i>
             <h2 class="text-center">Mot de passe oublié?</h2>
             <p>Réinitialiser votre mot de passe ici.</p>
-            <form class="form-signin">
+            <form id="password-reset-form" class="form-signin" method="post" action="send_email">
               <div class="form-label-group">
-                <input type="email" id="email-reset-form" class="form-control" placeholder="Email address">
+                <input name="email" type="email" id="email-reset-form" class="form-control" placeholder="Email address" required>
                 <label for="email-reset-form">Adresse courriel</label>
               </div>
               <button class="btn btn-lg btn-primary btn-block text-uppercase" type="submit">Réinitialiser votre mot de passe</button>

--- a/Core/View.php
+++ b/Core/View.php
@@ -53,6 +53,19 @@ class View
         echo $output;
     }
 
+    public static function outputTemplate($template, $args = [])
+    {
+        static $twig = null;
+
+        if ($twig === null) {
+            $loader = new \Twig_Loader_Filesystem(dirname(__DIR__) . '/App/Views');
+            $twig = new \Twig_Environment($loader);
+            $twig->addExtension(new \Twig_Extensions_Extension_Date());
+        }
+
+        return $twig->render($template, $args);
+    }
+
     public static function renderJSON($json)
     {
         $output = json_encode($json);

--- a/public/css/password_reset.css
+++ b/public/css/password_reset.css
@@ -1,0 +1,33 @@
+body {
+  min-height: initial;
+}
+
+main {
+  display: grid;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+h1 {
+  margin-bottom: 2rem;
+}
+
+.password-reset-container {
+  text-align: center;
+  background-color: var(--wet-sand);
+  padding: 1rem;
+  border-radius: 1rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+form > * {
+  margin-bottom: 1rem;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -162,5 +162,11 @@ $router->add('admin/getNewsletterUpdater', ['controller' => 'Newsletters', 'acti
 $router->add('admin/sendUpdate', ['controller' => 'Newsletters', 'action' => 'saveNewsletterUpdate'], 'POST');
 
 
+// Password reset
+
+$router->add('password_reset', ['controller' => 'ForgotPassword', 'action' => 'showResetPage', 'allowed_variables' => ['token']]);
+$router->add('password_reset', ['controller' => 'ForgotPassword', 'action' => 'confirmReset'], 'POST');
+$router->add('send_email', ['controller' => 'ForgotPassword', 'action' => 'sendEmail'], 'POST');
+
 // Send the URI and Method to the dispatcher
 $router->dispatch($_SERVER['REQUEST_URI'], $_SERVER['REQUEST_METHOD']);

--- a/public/js/password_reset_form.js
+++ b/public/js/password_reset_form.js
@@ -1,0 +1,14 @@
+(() => {
+  $('#reset_form_password_confirmation').on('change', (e) => {
+    e.currentTarget.setCustomValidity('')
+  })
+
+  $('#reset_form').on('submit', () => {
+    if ($('#reset_form_password').val() != $('#reset_form_password_confirmation').val()) {
+      document
+        .getElementById('reset_form_password_confirmation')
+        .setCustomValidity('Les mots de passes ne sont pas identiques')
+      return false
+    }
+  })
+})()

--- a/public/js/reset.js
+++ b/public/js/reset.js
@@ -1,7 +1,32 @@
 (() => {
-  let resetForm = document.getElementById('reset-modal-container')
+  let loginModal = document.getElementById('login-modal')
   let loginModalContainer = document.getElementById('login-modal-container')
+  let resetForm = document.getElementById('reset-modal-container')
   let resetLoginLink = document.getElementById('reset-login-link')
+  let password_reset_form = document.getElementById('password-reset-form')
+  let sent = false
+
+  $('#password-reset-form').ajaxForm({
+    beforeSend: (data) => {
+      if (sent)
+        return false
+      sent = true
+    },
+    success: () => {
+      password_reset_form.reset()
+      resetForm.classList.add('hidden')
+      loginModalContainer.classList.remove('hidden')
+      loginModal.classList.add('hidden')
+      showToast('Succès', '', 'Un email a été envoyé à l\'adresse spécifiée')
+    },
+    error: () => {
+      resetForm.classList.add('hidden')
+      loginModalContainer.classList.remove('hidden')
+      loginModal.classList.add('hidden')
+      showToast('Erreur', '', 'Une erreur est survenue')
+    }
+  })
+
   resetLoginLink.onclick = () => {
     resetForm.classList.add('hidden')
     loginModalContainer.classList.remove('hidden')


### PR DESCRIPTION
This PR adds functional password reset feature.

It works by sending an email to the email address specified by the user in the password reset form.

The app does not send an email if the account doesn't exists but let's the user believe it did. This feature is intentional since we don't want a malicious user finding other users email addresses by trying them with the form.